### PR TITLE
Fix DESTDIR, and add INSTALLDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,17 @@
-DESTDIR := /tmp/retroarch-assets
+INSTALLDIR := /usr/share/libretro/assets
 
 all:
 	@echo "Nothing to make for retroarch-assets."
 
 install:
-	mkdir -p $(DESTDIR)
-	cp -ar * $(DESTDIR)
-	rm -rf $(DESTDIR)/Makefile $(DESTDIR)/configure $(DESTDIR)/xmb/monochrome/src $(DESTDIR)/xmb/flatui/src $(DESTDIR)/xmb/dot-art/src
+	mkdir -p $(DESTDIR)$(INSTALLDIR)
+	cp -ar * $(DESTDIR)$(INSTALLDIR)
+	rm -rf $(DESTDIR)$(INSTALLDIR)/Makefile \
+		$(DESTDIR)$(INSTALLDIR)/COPYING \
+		$(DESTDIR)$(INSTALLDIR)/configure \
+		$(DESTDIR)$(INSTALLDIR)/xmb/monochrome/src \
+		$(DESTDIR)$(INSTALLDIR)/xmb/flatui/src \
+		$(DESTDIR)$(INSTALLDIR)/xmb/dot-art/src
+
+test-install: all
+	DESTDIR=/tmp/build $(MAKE) install


### PR DESCRIPTION
`DESTDIR` is the root of the file system, not where the package should be installed. This introduces a `INSTALLDIR` to allow changing install destination.

https://www.gnu.org/prep/standards/html_node/DESTDIR.html