### PR TITLE
Fix convert.sh

### DIFF
--- a/xmb/convert.sh
+++ b/xmb/convert.sh
@@ -17,4 +17,6 @@
 #     ./convert.sh monochrome battery-full
 #     ./convert.sh flatui DOS
 
-inkscape -z -e "$1/png/$2.png" -w 256 -h 256 "$1/src/$2.svg"
+cd -- "$(cd -- "$(dirname -- "$0")" && pwd -P)"
+
+inkscape -z -e "$1/png/$2.png" -w 256 -h 256 "../src/xmb/$1/$2.svg"


### PR DESCRIPTION
I failed to notice that `convert.sh` needed to be updated too when the source svg files moved. This does that and adds one more line so that it works even when executed from the wrong directory as it will always change to the directory the script is located before doing anything.