### PR TITLE
Create assets_bundle.yml

### DIFF
--- a/.github/workflows/assets_bundle.yml
+++ b/.github/workflows/assets_bundle.yml
@@ -1,0 +1,29 @@
+name: RetroArch Assets Bundle
+
+on:
+  # Trigger the workflow on push,
+  # but only for the master branch
+  push:
+    branches:
+      - master
+  watch: # this is a hack that lets repo owners trigger a build by starring
+    types: [started]
+    if: github.actor == github.event.repository.owner.login
+
+jobs:
+  Assets:
+    name: Bundle Assets for RetroArch
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - run: rm -rf branding wallpaper/* src .git configure Makefile COPYING
+    - run: 7z a -mx=9 assets.7z *
+    - name: Upload assets bundle
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: assets.7z
+        tag: Latest
+        asset_name: assets.7z
+        overwrite: true


### PR DESCRIPTION
This recipe compiles the assets into a bundle that is identical to the one on the buildbot server (AFAICT), which is downloaded from the online updater's "update assets" function.

The recipe runs on any push to master or when an owner of the repo stars the repo (as a way to trigger manual builds, which github actions can't do for some reason) and then publishes the bundle to a single 'Latest' tag, overwriting the previous bundle.