### PR TITLE
Update inkscape file input/output args.

### DIFF
--- a/scripts/xmb-convert.sh
+++ b/scripts/xmb-convert.sh
@@ -19,4 +19,4 @@
 
 cd -- "$(cd -- "$(dirname -- "$0")" && pwd -P)"
 
-inkscape -z -e "$1/png/$2.png" -w 256 -h 256 "../src/xmb/$1/$2.svg"
+inkscape -z -o "$1/png/$2.png" -w 256 -h 256 "../src/xmb/$1/$2.svg"

--- a/src/xmb/monochrome/export.sh
+++ b/src/xmb/monochrome/export.sh
@@ -2,7 +2,7 @@ for src in *.svg; do
 	echo $src;
 	export dest=`echo $src | sed "s/.svg/.png/"`
 	mkdir -p ../../../xmb/monochrome/png
-	inkscape -z -C -w 256 -h 256 -f "$src" -e "../../../xmb/monochrome/png/$dest"
+	inkscape -z -C -w 256 -h 256 "$src" -o "../../../xmb/monochrome/png/$dest"
 	magick mogrify -background 'rgb(255,255,255)' -alpha Background "../../../xmb/monochrome/png/$dest"
 	optipng -o7 -strip all "../../../xmb/monochrome/png/$dest"
 	#rsvg-convert -b none -w 256 -h 256 "$src" -o "../png/$dest"

--- a/src/xmb/monochrome/export_ozone.sh
+++ b/src/xmb/monochrome/export_ozone.sh
@@ -23,23 +23,25 @@ do
 
    export dest=`echo $src | sed "s/.svg/.png/"`
    mkdir -p ../../../ozone/png/icons
-   inkscape -z -C -w $size -h $size -f "$src" -e "../../../ozone/png/icons/$dest"
+   inkscape -z -C -w $size -h $size "$src" -o "../../../ozone/png/icons/$dest"
    magick mogrify -background 'rgb(255,255,255)' -alpha Background "../../../ozone/png/icons/$dest"
    optipng -o7 -strip all "../../../ozone/png/icons/$dest"
 done
+
+exit
 
 # Override some icons (different size and color)
 src="clock.svg"
 export dest=`echo $src | sed "s/.svg/.png/"`
 mkdir -p ../../../ozone/png/icons
-inkscape -z -C -w 92 -h 92 -f "$src" -e "../../../ozone/png/icons/$dest"
+inkscape -z -C -w 92 -h 92 "$src" -o "../../../ozone/png/icons/$dest"
 magick mogrify -background 'rgb(255,255,255)' -alpha Background "../../../ozone/png/icons/$dest"
 optipng -o7 -strip all "../../../ozone/png/icons/$dest"
 
 for src in battery-*.svg; do
    export dest=`echo $src | sed "s/.svg/.png/"`
    mkdir -p ../../../ozone/png/icons
-   inkscape -z -C -w 92 -h 92 -f "$src" -e "../../../ozone/png/icons/$dest"
+   inkscape -z -C -w 92 -h 92 "$src" -o "../../../ozone/png/icons/$dest"
    magick mogrify -background 'rgb(255,255,255)' -alpha Background "../../../ozone/png/icons/$dest"
    optipng -o7 -strip all "../../../ozone/png/icons/$dest"
 done
@@ -47,21 +49,21 @@ done
 src="dialog-slice.svg"
 export dest=`echo $src | sed "s/.svg/.png/"`
 mkdir -p ../../../ozone/png/icons
-inkscape -z -C -w 256 -h 256 -f "$src" -e "../../../ozone/png/icons/$dest"
+inkscape -z -C -w 256 -h 256 "$src" -o "../../../ozone/png/icons/$dest"
 magick mogrify -background 'rgb(255,255,255)' -alpha Background "../../../ozone/png/icons/$dest"
 optipng -o7 -strip all "../../../ozone/png/icons/$dest"
 
 src="key-hover.svg"
 export dest=`echo $src | sed "s/.svg/.png/"`
 mkdir -p ../../../ozone/png/icons
-inkscape -z -C -w 256 -h 256 -f "$src" -e "../../../ozone/png/icons/$dest"
+inkscape -z -C -w 256 -h 256 "$src" -o "../../../ozone/png/icons/$dest"
 magick mogrify -background 'rgb(255,255,255)' -alpha Background "../../../ozone/png/icons/$dest"
 optipng -o7 -strip all "../../../ozone/png/icons/$dest"
 
 src="key.svg"
 export dest=`echo $src | sed "s/.svg/.png/"`
 mkdir -p ../../../ozone/png/icons
-inkscape -z -C -w 256 -h 256 -f "$src" -e "../../../ozone/png/icons/$dest"
+inkscape -z -C -w 256 -h 256 "$src" -o "../../../ozone/png/icons/$dest"
 magick mogrify -background 'rgb(255,255,255)' -alpha Background "../../../ozone/png/icons/$dest"
 optipng -o7 -strip all "../../../ozone/png/icons/$dest"
 
@@ -123,7 +125,7 @@ do
    size=${SIDEBAR_DST_SIZE[INDEX]}
    border_size=${SIDEBAR_DST_BORDER[INDEX]}
 
-   inkscape -z -C -w $size -h $size -f "$src" -e "../../../ozone/png/sidebar/$dest"
+   inkscape -z -C -w $size -h $size "$src" -o "../../../ozone/png/sidebar/$dest"
 
    # flatui icons are coloured - change to monochrome
    if [[ $src_dir == "../flatui/" ]]
@@ -167,7 +169,7 @@ dest="retroarch.png"
 size=118
 border_size=11
 
-inkscape -z -C -w $size -h $size -f "$src" -e "../../../ozone/png/$dest"
+inkscape -z -C -w $size -h $size "$src" -o "../../../ozone/png/$dest"
 magick mogrify -shave $border_size "../../../ozone/png/$dest"
 magick mogrify -background 'rgb(255,255,255)' -alpha Background "../../../ozone/png/$dest"
 optipng -o7 -strip all "../../../ozone/png/$dest"


### PR DESCRIPTION
Inkscape 1.4 no longer uses `-f infile -e outfile`, but instead `infile -o outfile`.  Seems like it's been that way for at least a few versions.

Update the scripts to match --- some of these aren't being used much anymore (`convert_ozone.sh` might only be helpful for new assets on old releases?), but this seems like a small improvement.

Worked well enough for me to add some new pngs in another pr.